### PR TITLE
fix: dwm.exe crash

### DIFF
--- a/dwm-overlay/src/dllmain/dllmain.cpp
+++ b/dwm-overlay/src/dllmain/dllmain.cpp
@@ -172,7 +172,7 @@ DWORD WINAPI MainThread(LPVOID lpParameter)
 
 	MSG message {};
 
-	while (GetMessageW(&message, 0, 0, 0) > 0)
+	while (GetMessageW(&message, GetDesktopWindow(), 0, 0) > 0)
 	{
 		TranslateMessage(&message);
 		DispatchMessageW(&message);


### PR DESCRIPTION
Fix Windows 11 Insider Preview 10.0.26090.112 dwm.exe crash